### PR TITLE
feat(board): board 관련 CRUD 및 기능 구현

### DIFF
--- a/src/main/java/com/sparta/springtrello/domain/board/controller/BoardController.java
+++ b/src/main/java/com/sparta/springtrello/domain/board/controller/BoardController.java
@@ -7,11 +7,9 @@ import com.sparta.springtrello.domain.common.exception.CustomException;
 import com.sparta.springtrello.domain.common.response.ApiResponse;
 import com.sparta.springtrello.domain.user.entity.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,17 +18,17 @@ public class BoardController {
 
     private final BoardService boardService;
 
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping
     public ResponseEntity<ApiResponse<BoardResponse>> createBoard(
             @AuthenticationPrincipal CustomUserDetails authUser,
             @PathVariable Long workspaceId,
-            @RequestPart("boardRequest") BoardRequest boardRequest,
-            @RequestPart(value = "backgroundImage", required = false) MultipartFile backgroundImage) {
+            @RequestBody BoardRequest boardRequest) {
         if (authUser == null) {
             return ResponseEntity.status(403).body(new ApiResponse<>(403, "인증되지 않은 사용자입니다.", null));
         }
         try {
-            BoardResponse response = boardService.createBoard(authUser, workspaceId, boardRequest, backgroundImage);
+            // backgroundImage 는 boardRequest 내의 필드로 사용
+            BoardResponse response = boardService.createBoard(authUser, workspaceId, boardRequest);
             return ResponseEntity.ok(new ApiResponse<>(200, "정상처리되었습니다.", response));
         } catch (CustomException e) {
             return ResponseEntity.status(e.getStatus())
@@ -38,15 +36,14 @@ public class BoardController {
         }
     }
 
-    @PatchMapping(value = "/{boardId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PatchMapping("/{boardId}")
     public ResponseEntity<ApiResponse<BoardResponse>> updateBoard(
             @AuthenticationPrincipal CustomUserDetails authUser,
             @PathVariable Long workspaceId,
             @PathVariable Long boardId,
-            @RequestPart("boardRequest") BoardRequest boardRequest,
-            @RequestPart(value = "backgroundImage", required = false) MultipartFile backgroundImage) {
+            @RequestBody BoardRequest boardRequest) {
         try {
-            BoardResponse response = boardService.updateBoard(boardId, workspaceId, authUser, boardRequest, backgroundImage);
+            BoardResponse response = boardService.updateBoard(boardId, workspaceId, authUser, boardRequest);
             return ResponseEntity.ok(new ApiResponse<>(200, "정상처리되었습니다.", response));
         } catch (CustomException e) {
             return ResponseEntity.status(e.getStatus())
@@ -82,3 +79,4 @@ public class BoardController {
         }
     }
 }
+

--- a/src/main/java/com/sparta/springtrello/domain/board/controller/BoardController.java
+++ b/src/main/java/com/sparta/springtrello/domain/board/controller/BoardController.java
@@ -15,7 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/members/{memberId}/workspace/{workspaceId}/boards")
+@RequestMapping("/workspaces/{workspaceId}/boards")
 public class BoardController {
 
     private final BoardService boardService;
@@ -23,12 +23,14 @@ public class BoardController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<BoardResponse>> createBoard(
             @AuthenticationPrincipal CustomUserDetails authUser,
-            @PathVariable Long memberId,
             @PathVariable Long workspaceId,
             @RequestPart("boardRequest") BoardRequest boardRequest,
             @RequestPart(value = "backgroundImage", required = false) MultipartFile backgroundImage) {
+        if (authUser == null) {
+            return ResponseEntity.status(403).body(new ApiResponse<>(403, "인증되지 않은 사용자입니다.", null));
+        }
         try {
-            BoardResponse response = boardService.createBoard(authUser, memberId, workspaceId, boardRequest, backgroundImage);
+            BoardResponse response = boardService.createBoard(authUser, workspaceId, boardRequest, backgroundImage);
             return ResponseEntity.ok(new ApiResponse<>(200, "정상처리되었습니다.", response));
         } catch (CustomException e) {
             return ResponseEntity.status(e.getStatus())
@@ -39,13 +41,12 @@ public class BoardController {
     @PatchMapping(value = "/{boardId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<BoardResponse>> updateBoard(
             @AuthenticationPrincipal CustomUserDetails authUser,
-            @PathVariable Long memberId,
             @PathVariable Long workspaceId,
             @PathVariable Long boardId,
             @RequestPart("boardRequest") BoardRequest boardRequest,
             @RequestPart(value = "backgroundImage", required = false) MultipartFile backgroundImage) {
         try {
-            BoardResponse response = boardService.updateBoard(memberId, boardId, workspaceId, authUser, boardRequest, backgroundImage);
+            BoardResponse response = boardService.updateBoard(boardId, workspaceId, authUser, boardRequest, backgroundImage);
             return ResponseEntity.ok(new ApiResponse<>(200, "정상처리되었습니다.", response));
         } catch (CustomException e) {
             return ResponseEntity.status(e.getStatus())
@@ -55,12 +56,11 @@ public class BoardController {
 
     @DeleteMapping("/{boardId}")
     public ResponseEntity<ApiResponse<Void>> deleteBoard(
-            @PathVariable Long memberId,
             @PathVariable Long boardId,
             @PathVariable Long workspaceId,
             @AuthenticationPrincipal CustomUserDetails authUser) {
         try {
-            boardService.deleteBoard(memberId, boardId, workspaceId, authUser);
+            boardService.deleteBoard(boardId, workspaceId, authUser);
             return ResponseEntity.ok(new ApiResponse<>(200, "보드가 성공적으로 삭제되었습니다.", null));
         } catch (CustomException e) {
             return ResponseEntity.status(e.getStatus())
@@ -70,12 +70,11 @@ public class BoardController {
 
     @GetMapping("/{boardId}")
     public ResponseEntity<ApiResponse<BoardResponse>> getBoard(
-            @PathVariable Long memberId,
             @PathVariable Long boardId,
             @PathVariable Long workspaceId,
             @AuthenticationPrincipal CustomUserDetails authUser) {
         try {
-            BoardResponse response = boardService.getBoard(memberId, boardId, workspaceId, authUser);
+            BoardResponse response = boardService.getBoard(boardId, workspaceId, authUser);
             return ResponseEntity.ok(new ApiResponse<>(200, "정상처리되었습니다.", response));
         } catch (CustomException e) {
             return ResponseEntity.status(e.getStatus())

--- a/src/main/java/com/sparta/springtrello/domain/board/controller/BoardImageController.java
+++ b/src/main/java/com/sparta/springtrello/domain/board/controller/BoardImageController.java
@@ -1,0 +1,29 @@
+package com.sparta.springtrello.domain.board.controller;
+
+import com.sparta.springtrello.domain.board.service.BoardImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/boards")
+public class BoardImageController {
+
+    private final BoardImageService boardImageService;
+
+    @PostMapping("/upload")
+    public ResponseEntity<String> uploadProfileImage(@RequestParam("image") MultipartFile image) {
+        String imageUrl = boardImageService.upload(image);
+        return new ResponseEntity<>(imageUrl, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/delete")
+    public ResponseEntity<String> deleteProfileImage(@RequestParam("imageUrl") String imageUrl) {
+        boardImageService.deleteImageFromS3(imageUrl);
+        return new ResponseEntity<>("Image deleted successfully", HttpStatus.OK);
+    }
+}
+

--- a/src/main/java/com/sparta/springtrello/domain/board/dto/request/BoardRequest.java
+++ b/src/main/java/com/sparta/springtrello/domain/board/dto/request/BoardRequest.java
@@ -1,9 +1,13 @@
 package com.sparta.springtrello.domain.board.dto.request;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class BoardRequest {
     @NotNull
     private String title;

--- a/src/main/java/com/sparta/springtrello/domain/board/dto/request/BoardRequest.java
+++ b/src/main/java/com/sparta/springtrello/domain/board/dto/request/BoardRequest.java
@@ -4,6 +4,9 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @NoArgsConstructor
@@ -13,5 +16,6 @@ public class BoardRequest {
     private String title;
 
     private String backgroundColor;
+
     private String backgroundImageUrl;
 }

--- a/src/main/java/com/sparta/springtrello/domain/board/entity/BoardEntity.java
+++ b/src/main/java/com/sparta/springtrello/domain/board/entity/BoardEntity.java
@@ -34,18 +34,15 @@ public class BoardEntity extends Timestamped {
     @JoinColumn(name = "workspace_id", nullable = false)
     private WorkspaceEntity workspace;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "created_by")
-    private UserEntity createdBy;
-
     // 관계 설정: Board 는 여러 List 를 가질 수 있음
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ListEntity> lists = new ArrayList<>();
 
-    public BoardEntity(String title, String backgroundColor, String backgroundImageUrl) {
+    public BoardEntity(String title, String backgroundColor, String backgroundImageUrl, WorkspaceEntity workspace) {
         this.title = title;
         this.backgroundColor = backgroundColor;
         this.backgroundImageUrl = backgroundImageUrl;
+        this.workspace = workspace;
     }
 
     public void update(String updatedTitle, String updatedBackgroundColor, String updatedBackgroundImageUrl) {

--- a/src/main/java/com/sparta/springtrello/domain/board/service/BoardService.java
+++ b/src/main/java/com/sparta/springtrello/domain/board/service/BoardService.java
@@ -17,7 +17,6 @@ import com.sparta.springtrello.domain.workspace.repository.WorkspaceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -32,48 +31,41 @@ public class BoardService {
     private final BoardImageService boardImageService;
 
     @Transactional
-    public BoardResponse createBoard(CustomUserDetails authUser, Long workspaceId, BoardRequest boardRequest, MultipartFile backgroundImage) {
+    public BoardResponse createBoard(CustomUserDetails authUser, Long workspaceId, BoardRequest boardRequest) {
         // User 인증
         UserEntity user = UserEntity.fromAuthUser(authUser);
 
         // 멤버 여부 확인
-        // 워크스페이스에 속한 멤버 여부 확인
         MemberEntity member = memberRepository.findByUserIdAndWorkspaceId(user.getId(), workspaceId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 워크스페이스에 가입된 멤버가 아닙니다."));
 
-        // 읽기 전용 멤버는 보드 생성이 불가능
+        // 읽기 전용 멤버는 보드를 생성할 수 없음
         validatePermission(member);
 
-        // WorkspaceEntity 찾기
+        // 워크스페이스 찾기
         WorkspaceEntity workspace = workspaceRepository.findById(workspaceId)
                 .orElseThrow(() -> new CustomException(404, "해당 워크스페이스를 찾을 수 없습니다."));
 
-        // 배경 이미지 업로드 (배경 이미지가 있으면 업로드 후 URL 설정)
-        String backgroundImageUrl = null;
-        if (backgroundImage != null && !backgroundImage.isEmpty()) {
-            backgroundImageUrl = boardImageService.upload(backgroundImage);
-        }
-
-        // 배경색과 배경 이미지 URL 중 하나라도 입력이 없으면 기본값으로 설정
+        // 배경색 설정 (없으면 기본값)
         String backgroundColor = boardRequest.getBackgroundColor() != null ? boardRequest.getBackgroundColor() : "#FFFFFF";
 
-        // BoardEntity 생성
+        // 보드 생성
         BoardEntity board = new BoardEntity(
                 boardRequest.getTitle(),
                 backgroundColor,
-                backgroundImageUrl,
+                boardRequest.getBackgroundImageUrl(),
                 workspace
         );
 
-        // 제목이 비어 있으면 예외 처리
+        // 제목 유효성 검사
         if (boardRequest.getTitle() == null || boardRequest.getTitle().isEmpty()) {
             throw new CustomException(400, "제목이 비어 있습니다.");
         }
 
-        // 저장
+        // 보드 저장
         BoardEntity savedBoard = boardRepository.save(board);
 
-        // BoardResponse 반환
+        // 결과 반환
         return new BoardResponse(
                 savedBoard.getId(),
                 savedBoard.getTitle(),
@@ -85,7 +77,7 @@ public class BoardService {
     }
 
     @Transactional
-    public BoardResponse updateBoard(Long boardId, Long workspaceId, CustomUserDetails authUser, BoardRequest boardRequest, MultipartFile backgroundImage) {
+    public BoardResponse updateBoard(Long boardId, Long workspaceId, CustomUserDetails authUser, BoardRequest boardRequest) {
         // User 인증
         UserEntity user = UserEntity.fromAuthUser(authUser);
 
@@ -96,32 +88,26 @@ public class BoardService {
         // 읽기 전용 멤버는 보드를 수정할 수 없음
         validatePermission(member);
 
-        // BoardEntity 찾기햐
+        // BoardEntity 찾기
         BoardEntity existingBoard = boardRepository.findById(boardId)
                 .orElseThrow(() -> new CustomException(404, "해당 보드를 찾을 수 없습니다."));
-
-        // 배경 이미지 업로드 (배경 이미지가 있으면 업로드 후 URL 설정)
-        String backgroundImageUrl = boardRequest.getBackgroundImageUrl(); // 기존 값
-        if (backgroundImage != null && !backgroundImage.isEmpty()) {
-            backgroundImageUrl = boardImageService.upload(backgroundImage); // 새로운 이미지 URL
-        }
 
         // 배경색과 이미지 업데이트 처리
         String updatedTitle = boardRequest.getTitle();
         String updatedBackgroundColor = boardRequest.getBackgroundColor() != null ? boardRequest.getBackgroundColor() : existingBoard.getBackgroundColor();
-        String updatedBackgroundImageUrl = backgroundImageUrl != null ? backgroundImageUrl : existingBoard.getBackgroundImageUrl();
+        String updatedBackgroundImageUrl = boardRequest.getBackgroundImageUrl();
 
         existingBoard.update(updatedTitle, updatedBackgroundColor, updatedBackgroundImageUrl);
 
-        // 제목이 비어 있으면 예외 처리
-        if (boardRequest.getTitle() == null || boardRequest.getTitle().isEmpty()) {
+        // 제목 유효성 검사
+        if (updatedTitle == null || updatedTitle.isEmpty()) {
             throw new CustomException(400, "보드 제목은 필수 항목입니다.");
         }
 
-        // 저장
+        // 보드 저장
         BoardEntity savedBoard = boardRepository.save(existingBoard);
 
-        // BoardResponse 반환
+        // 결과 반환
         return new BoardResponse(
                 savedBoard.getId(),
                 savedBoard.getTitle(),
@@ -158,7 +144,7 @@ public class BoardService {
         UserEntity user = UserEntity.fromAuthUser(authUser);
 
         // 워크스페이스 멤버 여부 확인
-        MemberEntity member = memberRepository.findByUserIdAndWorkspaceId(user.getId(), workspaceId)
+        memberRepository.findByUserIdAndWorkspaceId(user.getId(), workspaceId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 워크스페이스에 가입된 멤버가 아닙니다."));
 
         // 보드 존재 여부 확인

--- a/src/main/java/com/sparta/springtrello/domain/common/exception/CustomException.java
+++ b/src/main/java/com/sparta/springtrello/domain/common/exception/CustomException.java
@@ -1,5 +1,8 @@
 package com.sparta.springtrello.domain.common.exception;
 
+import lombok.Getter;
+
+@Getter
 public class CustomException extends RuntimeException {
     private final int status;
 
@@ -8,7 +11,4 @@ public class CustomException extends RuntimeException {
         this.status = status;
     }
 
-    public int getStatus() {
-      return status;
-    }
 }

--- a/src/main/java/com/sparta/springtrello/domain/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/springtrello/domain/common/exception/GlobalExceptionHandler.java
@@ -7,13 +7,14 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
-public class GlobalExceptionHandler extends RuntimeException {
+public class GlobalExceptionHandler {
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ApiResponse<Void>> handlerIllegalArgumentException(CustomException e) {
-        ApiResponse<Void> response = new ApiResponse<>(e.getStatus(), e.getMessage(), null);
-        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
-    }
+  @ExceptionHandler(CustomException.class)
+  public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {
+    ApiResponse<Void> response = new ApiResponse<>(e.getStatus(), e.getMessage(), null);
+    HttpStatus status = HttpStatus.valueOf(e.getStatus());
+    return new ResponseEntity<>(response, status);
+  }
 
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ApiResponse<Void>> handleGeneralException(Exception ex) {

--- a/src/main/java/com/sparta/springtrello/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sparta/springtrello/domain/member/repository/MemberRepository.java
@@ -4,7 +4,11 @@ import com.sparta.springtrello.domain.member.entity.MemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
     List<MemberEntity> findAllByUserId(Long userId);
+
+    // 유저 ID와 워크스페이스 ID로 멤버를 찾는 메서드
+    Optional<MemberEntity> findByUserIdAndWorkspaceId(Long id, Long workspaceId);
 }

--- a/src/main/java/com/sparta/springtrello/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/springtrello/domain/user/repository/UserRepository.java
@@ -1,8 +1,6 @@
 package com.sparta.springtrello.domain.user.repository;
 
 import com.sparta.springtrello.domain.user.entity.UserEntity;
-import org.apache.catalina.User;
-import org.springframework.data.domain.Example;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -10,8 +8,4 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
     boolean existsByEmail(String email);
     Optional<UserEntity> findByEmail(String email);
-
-//    default User findByEmailOrElseThrow(String email) {
-//        return this.findByEmail(email).orElseThrow(()->new UserNotFoundException("유저를 찾을수 없습니다"));
-//    }
 }

--- a/src/main/java/com/sparta/springtrello/domain/workspace/dto/response/WorkspaceResponse.java
+++ b/src/main/java/com/sparta/springtrello/domain/workspace/dto/response/WorkspaceResponse.java
@@ -1,7 +1,5 @@
 package com.sparta.springtrello.domain.workspace.dto.response;
 
-import com.sparta.springtrello.domain.member.entity.MemberEntity;
-import com.sparta.springtrello.domain.user.entity.UserEntity;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/sparta/springtrello/domain/workspace/service/WorkspaceService.java
+++ b/src/main/java/com/sparta/springtrello/domain/workspace/service/WorkspaceService.java
@@ -1,11 +1,8 @@
 package com.sparta.springtrello.domain.workspace.service;
 
-import com.sparta.springtrello.domain.member.entity.MemberEntity;
-import com.sparta.springtrello.domain.member.repository.MemberRepository;
 import com.sparta.springtrello.domain.user.entity.CustomUserDetails;
 import com.sparta.springtrello.domain.user.entity.UserEntity;
 import com.sparta.springtrello.domain.user.enums.UserRole;
-import com.sparta.springtrello.domain.user.repository.UserRepository;
 import com.sparta.springtrello.domain.workspace.dto.request.WorkspaceRequest;
 import com.sparta.springtrello.domain.workspace.dto.response.WorkspaceNameResponse;
 import com.sparta.springtrello.domain.workspace.dto.response.WorkspaceResponse;
@@ -54,9 +51,9 @@ public class WorkspaceService {
     }
 
     public List<WorkspaceNameResponse> getWorkspaces(CustomUserDetails authUser) {
-        // WorkspaceRepository의 findByMembers_UserId 메서드를 사용해 유저의 워크스페이스 목록 조회
+        // WorkspaceRepository 의 findByMembers_UserId 메서드를 사용해 유저의 워크스페이스 목록 조회
         List<WorkspaceEntity> workspaces = workspaceRepository.findByMembers_UserId(authUser.getId());
-        // WorkspaceEntity 목록을 WorkspaceNameResponse로 변환하여 반환
+        // WorkspaceEntity 목록을 WorkspaceNameResponse 로 변환하여 반환
         return workspaces.stream()
                 .map(workspace -> new WorkspaceNameResponse(workspace.getName()))
                 .collect(Collectors.toList());


### PR DESCRIPTION
- [x] 보드 생성: 워크스페이스 내에서 새로운 보드 생성 (제목 필수, 읽기 전용은 생성 불가)
- [x] 보드 조회: 자신이 속한 워크스페이스의 보드 조회 (단건 조회시 리스트와 카드도 함께 조회)
- [x] 보드 삭제: 보드 삭제 (읽기 전용은 부락, 삭제 시 보드 내 모든 리스트 데이터도 함께 삭제)  