### PR TITLE
fix(board): S3 업로드 분리 구현 후 이미지 업로드 로직 수정

### DIFF
--- a/src/main/java/com/sparta/springtrello/domain/board/controller/BoardImageController.java
+++ b/src/main/java/com/sparta/springtrello/domain/board/controller/BoardImageController.java
@@ -1,6 +1,7 @@
 package com.sparta.springtrello.domain.board.controller;
 
 import com.sparta.springtrello.domain.board.service.BoardImageService;
+import com.sparta.springtrello.domain.common.dto.UploadFileResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -9,21 +10,25 @@ import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/boards")
+@RequestMapping("/boards/images")
 public class BoardImageController {
 
     private final BoardImageService boardImageService;
 
-    @PostMapping("/upload")
-    public ResponseEntity<String> uploadProfileImage(@RequestParam("image") MultipartFile image) {
-        String imageUrl = boardImageService.upload(image);
-        return new ResponseEntity<>(imageUrl, HttpStatus.OK);
+    // 이미지 업로드 메서드
+    @PostMapping
+    public ResponseEntity<UploadFileResponse> uploadBoardImage(@RequestParam("image") MultipartFile image) {
+        // 업로드된 파일의 메타데이터 응답
+        UploadFileResponse uploadFileResponse = boardImageService.upload(image);
+        return new ResponseEntity<>(uploadFileResponse, HttpStatus.OK);
     }
 
-    @DeleteMapping("/delete")
-    public ResponseEntity<String> deleteProfileImage(@RequestParam("imageUrl") String imageUrl) {
-        boardImageService.deleteImageFromS3(imageUrl);
-        return new ResponseEntity<>("Image deleted successfully", HttpStatus.OK);
+    // 이미지 삭제 메서드
+    @DeleteMapping
+    public ResponseEntity<String> deleteBoardImage(@RequestParam("imageUrl") String imageUrl) {
+        // 이미지 삭제 처리
+        boardImageService.deleteBackgroundImage(imageUrl);
+        return new ResponseEntity<>("이미지가 성공적으로 삭제되었습니다.", HttpStatus.OK);
     }
 }
 

--- a/src/main/java/com/sparta/springtrello/domain/common/dto/UploadFileResponse.java
+++ b/src/main/java/com/sparta/springtrello/domain/common/dto/UploadFileResponse.java
@@ -1,0 +1,15 @@
+package com.sparta.springtrello.domain.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UploadFileResponse {
+    private String fileName;
+    private String fileExtension;
+    private Long fileSize;
+    private String fileUrl;
+}

--- a/src/main/java/com/sparta/springtrello/domain/common/service/S3UploadService.java
+++ b/src/main/java/com/sparta/springtrello/domain/common/service/S3UploadService.java
@@ -1,0 +1,90 @@
+package com.sparta.springtrello.domain.common.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.*;
+import com.amazonaws.util.IOUtils;
+import com.sparta.springtrello.domain.common.dto.UploadFileResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class S3UploadService {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucketName}")
+    private String bucketName;
+
+    public UploadFileResponse uploadImageToS3(MultipartFile image) throws IOException {
+        // 파일 이름과 확장자 추출
+        String originalFilename = image.getOriginalFilename();
+        String extension = originalFilename.substring(originalFilename.lastIndexOf(".") + 1); // 확장자 추출
+        String s3FileName = UUID.randomUUID().toString().substring(0, 10) + "_" + originalFilename;
+
+        // 파일 크기 및 메타데이터 설정
+        long fileSize = image.getSize();  // 파일 크기
+        InputStream inputStream = image.getInputStream();
+        byte[] bytes = IOUtils.toByteArray(inputStream);
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType("image/" + extension);
+        metadata.setContentLength(bytes.length);
+
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+
+        try {
+            // S3에 파일 업로드
+            PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, s3FileName, byteArrayInputStream, metadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead);
+
+            amazonS3.putObject(putObjectRequest);
+        } catch (AmazonS3Exception e) {
+            throw new AmazonS3Exception("이미지를 S3 버킷에 업로드할 수 없습니다.", e);
+        } finally {
+            byteArrayInputStream.close();
+            inputStream.close();
+        }
+
+        // 업로드된 파일의 URL 생성
+        String fileUrl = amazonS3.getUrl(bucketName, s3FileName).toString();
+
+        // UploadFileResponse 객체 반환 (파일 이름, 확장자, 파일 크기, URL)
+        return new UploadFileResponse(
+                originalFilename,  // 실제 파일 이름
+                extension,         // 파일 확장자
+                fileSize,          // 파일 크기
+                fileUrl            // S3에 저장된 파일 URL
+        );
+    }
+
+    public void deleteImageFromS3(String imageAddress) {
+        String key = getKeyFromImageAddress(imageAddress);
+        try {
+            amazonS3.deleteObject(new DeleteObjectRequest(bucketName, key));
+        } catch (AmazonS3Exception e) {
+            throw new AmazonS3Exception("이미지를 S3 버킷으로부터 삭제할 수 없습니다.", e);
+        }
+    }
+
+    public String getKeyFromImageAddress(String imageAddress) {
+        try {
+            URL url = new URL(imageAddress);
+            String decodingKey = URLDecoder.decode(url.getPath(), "UTF-8");
+            return decodingKey.substring(1);
+        } catch (MalformedURLException | UnsupportedEncodingException e) {
+            throw new AmazonS3Exception("유효하지 않은 이미지 URL입니다.", e);
+        }
+    }
+}


### PR DESCRIPTION
- [x]  BoardImageService로부터 S3UploadService 분리
- [x] S3UploadResponse에 파일이름, 확장자, 크기, URL 구현
- [x] BoardImageController와 BoardImageService 수정 완료 