### PR TITLE
feat(Concurrency Control): 동시성 제어 구현

### DIFF
--- a/src/main/java/com/sparta/springtrello/domain/card/entity/CardEntity.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/entity/CardEntity.java
@@ -48,6 +48,9 @@ public class CardEntity extends Timestamped {
     @OneToMany(mappedBy = "card", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<AttachmentEntity> attachments;// 추가된 부분
 
+    @Version
+    private Long version; // 동시성 제어를 위한 @Version 필드 추가
+
     public CardEntity(CardRequest cardRequest,ListEntity list){
         this.title = cardRequest.getTitle();
         this.description = cardRequest.getDescription();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,6 +14,9 @@ spring.jpa.properties.hibernate.use_sql_comments=true
 # jwt secretKey
 jwt.secret.key=${jwt.secret.key}
 
+# slack
+slack.webhook.url=${slack_webhook_url}
+
 # AWS S3
 cloud.aws.credentials.accessKey=${aws_accessKey}
 cloud.aws.credentials.secretKey=${aws_secretKey}


### PR DESCRIPTION
### 동시성 제어 구현

------

#### 낙관적 락 선택 이유

- **충돌 빈도가 낮은 시스템**: 충돌이 자주 발생하지 않는 환경인 것을 고려하여 낙관적 락 선택
- **데드락 방지**: 다수의 트랜잭션 동시에 처리 가능하여 별도의 락 관리 필요 X
- **비관적 락의 성능 저하 방지**: 불필요한 락으로 인한 성능 저하 방지 가능

------

#### 낙관적 락을 사용했을 때의 장점
- **성능 효율성**: 트랜잭션 종료 시점에만 충돌 여부를 검사하므로 자원 소모가 적고 트랜잭션을 빠르게 처리 가능
- **데드락 방지**: 데이터에 락을 걸지 않으므로 데드락 발생 위험이 적음
- **병행성 향상**: 데이터에 락을 걸지 않으므로 병행성 처리가 더 효과적이며 락으로 인한 대기 시간이 줄어듦

#### 낙관적 락을 사용했을 때의 단점
- **충돌이 발생할 경우 오버헤드**: 충돌이 발생하면 트랜잭션을 롤백하고 다시 처리해야 해서 재시도 필요하기 때문에 충돌이 자주 발생할 시 오버헤드로 인해 성능이 저하될 수 있음
- **충돌 발생 시 사용자 경험 저하**: 충돌이 발생할 경우 사용자가 변경사항을 다시 입력해야 하는 불편 발생
- **빈번한 데이터 충돌 발생 시 비효율적**: 동일한 데이터를 자주 수정하는 경우 충돌이 자주 발생할 수 있음

------

- [x] 엔티티: 카드 엔티티에 @Version 어노테이션 추가하여 JPA 엔티티 클래스의 버전 관리를 담당하게 적용
- [x] 서비스: 업로드할 때, 동시에 처리 요청이 들어왔을 때 사용자에게 예외처리를 반환
 
