### PR TITLE
feat(kh_dev): 카드 조회 시 캐시 사용 로직 추가

### DIFF
--- a/src/main/java/com/sparta/springtrello/SpringTrelloApplication.java
+++ b/src/main/java/com/sparta/springtrello/SpringTrelloApplication.java
@@ -2,10 +2,12 @@ package com.sparta.springtrello;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableCaching
 public class  SpringTrelloApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/sparta/springtrello/config/RedisConfig.java
+++ b/src/main/java/com/sparta/springtrello/config/RedisConfig.java
@@ -6,9 +6,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
+@EnableRedisRepositories
 public class RedisConfig {
     @Value("${spring.data.redis.host}")
     private String redisHost;
@@ -30,7 +32,7 @@ public class RedisConfig {
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());
 
-        // Hash를 사용할 경우 Serializer
+        // Hash 를 사용할 경우 Serializer
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
         redisTemplate.setHashValueSerializer(new StringRedisSerializer());
 

--- a/src/main/java/com/sparta/springtrello/config/RedisConfig.java
+++ b/src/main/java/com/sparta/springtrello/config/RedisConfig.java
@@ -6,11 +6,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
-@EnableRedisRepositories
 public class RedisConfig {
     @Value("${spring.data.redis.host}")
     private String redisHost;

--- a/src/main/java/com/sparta/springtrello/domain/card/controller/CardController.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/controller/CardController.java
@@ -6,10 +6,11 @@ import com.sparta.springtrello.domain.card.service.CardService;
 import com.sparta.springtrello.domain.common.response.ApiResponse;
 import com.sparta.springtrello.domain.user.entity.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Set;
 
 @RestController
 @RequestMapping("/lists")
@@ -26,11 +27,11 @@ public class CardController {
     }
 
     @GetMapping("/{cardId}")
-    public ResponseEntity<CardResponse> getCard(@AuthenticationPrincipal CustomUserDetails authUser, @PathVariable Long cardId) {
+    public ResponseEntity<ApiResponse<CardResponse>> getCard(@AuthenticationPrincipal CustomUserDetails authUser, @PathVariable Long cardId) {
 
         CardResponse response = cardService.getCard(authUser, cardId);
 
-        return ResponseEntity.status(HttpStatus.OK).body(response);
+        return ResponseEntity.ok(new ApiResponse<>(200, "카드가 성공적으로 조회되었습니다.", response));
     }
 
     @PatchMapping("/{listId}/cards/{cardId}")
@@ -47,4 +48,9 @@ public class CardController {
         return ResponseEntity.ok(new ApiResponse<>(200, "보드가 성공적으로 삭제되었습니다.", null));
     }
 
+    @GetMapping("/popular")
+    public ResponseEntity<Set<Object>> getPopularCards() {
+        Set<Object> popularCards = cardService.getPopularCards();
+        return ResponseEntity.ok(popularCards);
+    }
 }

--- a/src/main/java/com/sparta/springtrello/domain/card/repository/CardRepository.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/repository/CardRepository.java
@@ -11,5 +11,5 @@ import java.util.Optional;
 
 public interface CardRepository extends JpaRepository<CardEntity,Long>, CardRepositoryCustom {
 
-    Optional<CardEntity> findByListIdAndId(@Param("listId") Long listId, @Param("cardId") Long cardId);
+    Optional<CardEntity> findByListIdAndId(Long listId, Long cardId);
 }

--- a/src/main/java/com/sparta/springtrello/domain/card/repository/CardRepository.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/repository/CardRepository.java
@@ -1,11 +1,15 @@
 package com.sparta.springtrello.domain.card.repository;
 
 import com.sparta.springtrello.domain.card.entity.CardEntity;
+import io.lettuce.core.dynamic.annotation.Param;
+import jakarta.persistence.Entity;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface CardRepository extends JpaRepository<CardEntity,Long>, CardRepositoryCustom {
-    Optional<CardEntity> findByListIdAndId(Long listId, Long cardId);
 
+    Optional<CardEntity> findByListIdAndId(@Param("listId") Long listId, @Param("cardId") Long cardId);
 }

--- a/src/main/java/com/sparta/springtrello/domain/card/service/CardService.java
+++ b/src/main/java/com/sparta/springtrello/domain/card/service/CardService.java
@@ -18,15 +18,20 @@ import com.sparta.springtrello.domain.member.repository.MemberRepository;
 import com.sparta.springtrello.domain.notification.service.NotificationService;
 import com.sparta.springtrello.domain.user.entity.CustomUserDetails;
 import com.sparta.springtrello.domain.user.entity.UserEntity;
+import jakarta.persistence.Cacheable;
 import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 @Service
+@Cacheable
 @RequiredArgsConstructor
 public class CardService {
 
@@ -38,9 +43,10 @@ public class CardService {
     private final MemberRepository memberRepository;
     private final NotificationService notificationService;
 
+    private final RedisTemplate<String, Object> redisTemplate;
+
     @Transactional
     public CardResponse createCard(CustomUserDetails authUser,Long listId, CardRequest cardRequest) {
-
         UserEntity user = UserEntity.fromAuthUser(authUser);
 
         ListEntity list = listRepository.findById(listId).orElseThrow(()-> new CustomException(404, "리스트 ID를 찾을 수 없습니다."));
@@ -64,7 +70,7 @@ public class CardService {
     }
 
     @Transactional
-    public CardResponse getCard(CustomUserDetails authUser,Long cardId) {
+    public CardResponse getCard(CustomUserDetails authUser, Long cardId) {
         UserEntity user = UserEntity.fromAuthUser(authUser);
 
         CardEntity card = cardRepository.findById(cardId).orElseThrow(() -> new CustomException(404, "카드가 존재하지 않습니다."));
@@ -76,9 +82,14 @@ public class CardService {
 
         validatePermission(member);
 
-        List<AssigneeEntity> assigneeEntity = assigneeRepository.findByCardId(cardId);
+        // 조회수 증가 및 어뷰징 방지
+        incrementCardViewCount(cardId, user.getId());
 
-       List<CommentEntity> commentEntities = commentRepository.findByCardId(cardId);
+        // 인기 카드 업데이트
+        updatePopularCardRanking(String.valueOf(cardId));
+
+        List<AssigneeEntity> assigneeEntity = assigneeRepository.findByCardId(cardId);
+        List<CommentEntity> commentEntities = commentRepository.findByCardId(cardId);
 
         // 슬랙 알림 전송
         String message = String.format("%s님이 카드[%s]를 조회했습니다.", user.getEmail(), card.getTitle());
@@ -91,13 +102,12 @@ public class CardService {
 
     @Transactional
     public CardResponse updateCard(CustomUserDetails authUser,Long listId, Long cardId, CardRequest cardRequest) {
-
         UserEntity user = UserEntity.fromAuthUser(authUser);
 
         ListEntity list = listRepository.findById(listId).orElseThrow(()-> new CustomException(404, "리스트 ID를 찾을 수 없습니다."));
 
-        CardEntity card = cardRepository.findByListIdAndId(listId,cardId)
-                .orElseThrow(() -> new RuntimeException("Card not found"));
+        CardEntity card = cardRepository.findByListIdAndId(listId, cardId)
+                .orElseThrow(() -> new CustomException(404, "해당 카드를 찾을 수 없습니다."));
 
         MemberEntity member = memberRepository.findByUserIdAndWorkspaceId(user.getId(), list.getBoard().getWorkspace().getId())
                 .orElseThrow(() -> new CustomException(403, "해당 워크스페이스의 멤버가 아닙니다."));
@@ -121,7 +131,6 @@ public class CardService {
 
     @Transactional
     public void deleteCard(CustomUserDetails authUser,Long listId, Long cardId) {
-
         UserEntity user = UserEntity.fromAuthUser(authUser);
 
         ListEntity list = listRepository.findById(listId).orElseThrow(()-> new CustomException(404, "리스트 ID를 찾을 수 없습니다."));
@@ -141,6 +150,48 @@ public class CardService {
         notificationService.createNotification(message,  "card");
 
         cardRepository.delete(card);
+    }
+
+    // 카드 조회수 증가
+    public void incrementCardViewCount(Long cardId, Long userId) {
+        if (cardId == null || userId == null) {
+            throw new CustomException(400, "카드가 없거나 존재하지 않는 유저입니다.");
+        }
+
+        String cardViewKey = "card: " + cardId + ":views";
+        String userViewKey = "user: " + userId + ":cards:" + cardId;
+
+        if (Boolean.FALSE.equals(redisTemplate.hasKey(userViewKey))) {
+            redisTemplate.opsForValue().increment(cardViewKey);
+            redisTemplate.opsForValue().set(userViewKey, "1", 1, TimeUnit.DAYS);
+        }
+    }
+
+    // 인기 카드 랭킹 업데이트
+    public void updatePopularCardRanking(String cardId) {
+        String rankingKey = "card:ranking";
+        redisTemplate.opsForZSet().incrementScore(rankingKey, cardId, 1);
+    }
+
+    // 인기 카드 목록 조회
+    public Set<Object> getPopularCards() {
+        String rankingKey = "card:ranking";
+        return redisTemplate.opsForZSet().range(rankingKey, 0, 9); // 상위 10개 카드 조회
+    }
+
+    // 자정에 조회수 리셋
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void resetDailyCardViewCounts() {
+        String rankingKey = "card:ranking";
+        Set<String> cardKeys = redisTemplate.keys("card:*:views");
+
+        if (cardKeys != null && !cardKeys.isEmpty()) {
+            for (String key : cardKeys) {
+                redisTemplate.delete(key);
+            }
+        }
+
+        redisTemplate.delete(rankingKey);
     }
 
     private void validatePermission(MemberEntity member) {


### PR DESCRIPTION
# 카드 조회 시 조회수 카운팅을 위한 캐싱 사용

- 카드 조회 시 해당 카드의 조회수 증가
- 가장 인기 있는 카드 조회 랭킹 조회
- 동일한 유저가 조회수를 무한적으로 올리는 어뷰징 방지

- [x] SpringTrelloApplication: 캐싱 사용을 위한 어노테이션 추가
- [x] CardService: 카드 조회수 증가, 인기 카드 랭킹 업데이트, 인기 카드 목록 조회, 조회수 리셋 로직 구현
- [x] CardController: 인기 카드 목록 조회 로직 구현

⚠️ 모든 로직은 **Redis가 실행 중일 때** 사용 가능합니다. 사용법을 모르시겠다면 이전 PR을 참고해주세요.
⚠️ repository와 config에서의 불필요한 어노테이션은 뒤의 PR에서 삭제할 예정입니다.